### PR TITLE
Fix CI/CD errors after project rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ["1.21", "1.22"]
+        go-version: ["1.23", "1.24"]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
@@ -59,7 +59,7 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out ./...
 
       - name: Upload coverage to Codecov
-        if: matrix.go-version == '1.22'
+        if: matrix.go-version == '1.24'
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.out

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.24"
 
       - name: Get version from tag
         id: version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aoshimash/urlmap
 
-go 1.24.4
+go 1.24
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.3

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -208,9 +208,21 @@ func setupE2ETest(t *testing.T) (string, func()) {
 
 	// Build the urlmap binary
 	binaryPath := filepath.Join(tempDir, "urlmap")
-	cmd := exec.Command("go", "build", "-o", binaryPath, "./cmd/urlmap")
+
+	// Get project root directory
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+
+	// Navigate to project root (assuming we're in test/e2e)
+	projectRoot := filepath.Join(wd, "..", "..")
+	cmdPath := filepath.Join(projectRoot, "cmd", "urlmap")
+
+	cmd := exec.Command("go", "build", "-o", binaryPath, cmdPath)
+	cmd.Dir = projectRoot
 	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to build urlmap binary: %v", err)
+		t.Fatalf("Failed to build urlmap binary from %s: %v", cmdPath, err)
 	}
 
 	return binaryPath, func() {

--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -80,9 +80,21 @@ func setupCLITest(t *testing.T) (string, func()) {
 
 	// Build the urlmap binary
 	binaryPath := filepath.Join(tempDir, "urlmap")
-	cmd := exec.Command("go", "build", "-o", binaryPath, "./cmd/urlmap")
+
+	// Get project root directory
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+
+	// Navigate to project root (assuming we're in test/integration)
+	projectRoot := filepath.Join(wd, "..", "..")
+	cmdPath := filepath.Join(projectRoot, "cmd", "urlmap")
+
+	cmd := exec.Command("go", "build", "-o", binaryPath, cmdPath)
+	cmd.Dir = projectRoot
 	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to build urlmap binary: %v", err)
+		t.Fatalf("Failed to build urlmap binary from %s: %v", cmdPath, err)
 	}
 
 	return binaryPath, func() {
@@ -283,7 +295,7 @@ func TestVersionCommand(t *testing.T) {
 	}
 
 	outputStr := string(output)
-	if !strings.Contains(outputStr, "crawld version") {
+	if !strings.Contains(outputStr, "urlmap version") {
 		t.Errorf("Expected version output to contain version info, got: %s", outputStr)
 	}
 }


### PR DESCRIPTION
## 🐛 Problem

After merging PR #37 that renamed the project from `crawld` to `urlmap`, CI/CD workflows were failing due to version mismatches and incorrect build paths in tests.

## 🔧 Solution

This PR fixes all CI/CD errors by addressing the following issues:

### Go Version Updates
- **CI Workflow**: Updated Go matrix from `1.21, 1.22` to `1.23, 1.24` to match current development environment
- **Release Workflow**: Updated Go version from `1.21` to `1.24`
- **go.mod**: Fixed Go version specification from `1.24.4` to `1.24` (standard format)

### GitHub Actions Improvements
- Updated `setup-go` action from `v4` to `v5` for better compatibility
- Updated coverage upload condition to use Go `1.24` instead of `1.22`

### Test Infrastructure Fixes
- **E2E Tests**: Fixed binary build paths and working directory setup
- **Integration Tests**: Fixed binary build paths and working directory setup
- **Version Test**: Updated expected output from `crawld version` to `urlmap version`

## ✅ Testing

All tests now pass successfully:
- ✅ Unit tests for all internal packages
- ✅ E2E tests with proper binary building
- ✅ Integration tests with corrected paths
- ✅ Version command validation

## 📋 Changes Made

### CI/CD Configuration
- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`

### Project Configuration
- `go.mod`

### Test Infrastructure
- `test/e2e/e2e_test.go`
- `test/integration/cli_test.go`

## 🎯 Impact

- Fixes failing CI builds
- Enables proper release workflow
- Ensures all tests run correctly in CI environment
- Maintains compatibility with latest Go versions

## 🔍 Verification

The changes have been verified by running:
```bash
go test ./...
go build ./cmd/urlmap
```

All tests pass and the binary builds successfully.