### PR TITLE
refactor: replace all remaining crawld references with urlmap

### DIFF
--- a/cmd/urlmap/main_test.go
+++ b/cmd/urlmap/main_test.go
@@ -53,7 +53,7 @@ func TestRootCommand(t *testing.T) {
 func TestVersionCommand(t *testing.T) {
 	// Create a new command instance for isolated testing
 	cmd := &cobra.Command{
-		Use:   "crawld",
+		Use:   "urlmap",
 		Short: "Test command",
 	}
 
@@ -61,7 +61,7 @@ func TestVersionCommand(t *testing.T) {
 		Use:   "version",
 		Short: "Print version information",
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Printf("crawld version %s\n", version)
+			cmd.Printf("urlmap version %s\n", version)
 			cmd.Printf("commit: %s\n", commit)
 			cmd.Printf("built: %s\n", date)
 		},
@@ -80,8 +80,8 @@ func TestVersionCommand(t *testing.T) {
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "crawld version") {
-		t.Errorf("version output should contain 'crawld version', got: %s", output)
+	if !strings.Contains(output, "urlmap version") {
+		t.Errorf("version output should contain 'urlmap version', got: %s", output)
 	}
 	if !strings.Contains(output, "commit:") {
 		t.Errorf("version output should contain 'commit:', got: %s", output)
@@ -95,12 +95,12 @@ func TestFlagDefaults(t *testing.T) {
 	// Reset flags to default values
 	depth = 0
 	verbose = false
-	userAgent = "crawld/1.0.0 (+https://github.com/aoshimash/crawld)"
+	userAgent = "urlmap/1.0.0 (+https://github.com/aoshimash/urlmap)"
 	concurrent = 10
 
 	// Create a new command instance for isolated testing
 	cmd := &cobra.Command{
-		Use:  "crawld <URL>",
+		Use:  "urlmap <URL>",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Test default values
@@ -110,8 +110,8 @@ func TestFlagDefaults(t *testing.T) {
 			if verbose != false {
 				t.Errorf("verbose default should be false, got: %v", verbose)
 			}
-			if userAgent != "crawld/1.0.0 (+https://github.com/aoshimash/crawld)" {
-				t.Errorf("userAgent default should be 'crawld/1.0.0 (+https://github.com/aoshimash/crawld)', got: %s", userAgent)
+			if userAgent != "urlmap/1.0.0 (+https://github.com/aoshimash/urlmap)" {
+				t.Errorf("userAgent default should be 'urlmap/1.0.0 (+https://github.com/aoshimash/urlmap)', got: %s", userAgent)
 			}
 			if concurrent != 10 {
 				t.Errorf("concurrent default should be 10, got: %d", concurrent)
@@ -122,7 +122,7 @@ func TestFlagDefaults(t *testing.T) {
 
 	cmd.Flags().IntVarP(&depth, "depth", "d", 0, "Maximum crawl depth (0 = unlimited)")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
-	cmd.Flags().StringVarP(&userAgent, "user-agent", "u", "crawld/1.0.0 (+https://github.com/aoshimash/crawld)", "Custom User-Agent string")
+	cmd.Flags().StringVarP(&userAgent, "user-agent", "u", "urlmap/1.0.0 (+https://github.com/aoshimash/urlmap)", "Custom User-Agent string")
 	cmd.Flags().IntVarP(&concurrent, "concurrent", "c", 10, "Number of concurrent requests")
 
 	cmd.SetArgs([]string{"https://example.com"})
@@ -165,11 +165,11 @@ func TestFlagParsing(t *testing.T) {
 			// Reset flags
 			depth = 0
 			verbose = false
-			userAgent = "crawld/1.0.0 (+https://github.com/aoshimash/crawld)"
+			userAgent = "urlmap/1.0.0 (+https://github.com/aoshimash/urlmap)"
 			concurrent = 10
 
 			cmd := &cobra.Command{
-				Use:  "crawld <URL>",
+				Use:  "urlmap <URL>",
 				Args: cobra.ExactArgs(1),
 				RunE: func(cmd *cobra.Command, args []string) error {
 					// Test parsed values
@@ -191,7 +191,7 @@ func TestFlagParsing(t *testing.T) {
 
 			cmd.Flags().IntVarP(&depth, "depth", "d", 0, "Maximum crawl depth (0 = unlimited)")
 			cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
-			cmd.Flags().StringVarP(&userAgent, "user-agent", "u", "crawld/1.0.0 (+https://github.com/aoshimash/crawld)", "Custom User-Agent string")
+			cmd.Flags().StringVarP(&userAgent, "user-agent", "u", "urlmap/1.0.0 (+https://github.com/aoshimash/urlmap)", "Custom User-Agent string")
 			cmd.Flags().IntVarP(&concurrent, "concurrent", "c", 10, "Number of concurrent requests")
 
 			cmd.SetArgs(tt.args)
@@ -232,7 +232,7 @@ func TestExecute(t *testing.T) {
 	defer func() { os.Args = originalArgs }()
 
 	// Test version command
-	os.Args = []string{"crawld", "version"}
+	os.Args = []string{"urlmap", "version"}
 
 	// This test mainly ensures Execute() doesn't panic
 	// and runs without fatal errors

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
-# crawld Architecture
+# urlmap Architecture
 
-This document provides a comprehensive overview of the crawld architecture, design decisions, and implementation details.
+This document provides a comprehensive overview of the urlmap architecture, design decisions, and implementation details.
 
 ## 📋 Table of Contents
 
@@ -17,7 +17,7 @@ This document provides a comprehensive overview of the crawld architecture, desi
 
 ## 🏗 Overview
 
-crawld is a concurrent web crawler designed for discovering and extracting links from websites. It follows a modular architecture with clear separation of concerns, enabling maintainability, testability, and extensibility.
+urlmap is a concurrent web crawler designed for discovering and extracting links from websites. It follows a modular architecture with clear separation of concerns, enabling maintainability, testability, and extensibility.
 
 ### Key Design Principles
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,6 +1,6 @@
-# crawld Performance Guide
+# urlmap Performance Guide
 
-This document provides comprehensive performance benchmarks, optimization techniques, and best practices for using crawld efficiently.
+This document provides comprehensive performance benchmarks, optimization techniques, and best practices for using urlmap efficiently.
 
 ## 📋 Table of Contents
 
@@ -15,7 +15,7 @@ This document provides comprehensive performance benchmarks, optimization techni
 
 ## 🏁 Performance Overview
 
-crawld is designed for high-performance web crawling with the following characteristics:
+urlmap is designed for high-performance web crawling with the following characteristics:
 
 ### Key Performance Features
 
@@ -39,7 +39,7 @@ crawld is designed for high-performance web crawling with the following characte
 - **Hardware**: MacBook Pro M2, 16GB RAM
 - **Network**: 100 Mbps connection
 - **Go Version**: 1.21.0
-- **crawld Version**: v1.0.0
+- **urlmap Version**: v1.0.0
 
 ### Small Sites (< 100 URLs)
 
@@ -88,7 +88,7 @@ crawld is designed for high-performance web crawling with the following characte
 # Test different worker counts
 for workers in 5 10 20 30 50; do
     echo "Testing with $workers workers:"
-    time crawld --concurrent $workers --depth 3 https://example.com > /dev/null
+    time urlmap --concurrent $workers --depth 3 https://example.com > /dev/null
 done
 ```
 
@@ -132,7 +132,7 @@ func (p *Parser) ExtractLinksFromString(content string) ([]string, error) {
 
 ```bash
 # Monitor connection reuse
-crawld --verbose https://example.com 2>&1 | grep -i "connection"
+urlmap --verbose https://example.com 2>&1 | grep -i "connection"
 ```
 
 #### Request Batching
@@ -147,10 +147,10 @@ crawld --verbose https://example.com 2>&1 | grep -i "connection"
 
 ```bash
 # Conservative approach for production
-crawld --concurrent 10 --rate-limit 5 --depth 5 https://example.com
+urlmap --concurrent 10 --rate-limit 5 --depth 5 https://example.com
 
 # Aggressive approach for testing (use with caution)
-crawld --concurrent 50 --rate-limit 20 --depth 3 https://example.com
+urlmap --concurrent 50 --rate-limit 20 --depth 3 https://example.com
 ```
 
 #### Adaptive Rate Limiting
@@ -165,27 +165,27 @@ crawld --concurrent 50 --rate-limit 20 --depth 3 https://example.com
 
 #### For Small Sites (< 100 URLs)
 ```bash
-crawld --concurrent 20 --depth 3 https://small-site.com
+urlmap --concurrent 20 --depth 3 https://small-site.com
 ```
 
 #### For Medium Sites (100-1,000 URLs)
 ```bash
-crawld --concurrent 30 --rate-limit 10 --depth 5 https://medium-site.com
+urlmap --concurrent 30 --rate-limit 10 --depth 5 https://medium-site.com
 ```
 
 #### For Large Sites (> 1,000 URLs)
 ```bash
-crawld --concurrent 50 --rate-limit 15 --depth 5 https://large-site.com --verbose
+urlmap --concurrent 50 --rate-limit 15 --depth 5 https://large-site.com --verbose
 ```
 
 #### Memory-Constrained Environments
 ```bash
-crawld --concurrent 10 --rate-limit 5 --depth 3 https://example.com
+urlmap --concurrent 10 --rate-limit 5 --depth 3 https://example.com
 ```
 
 #### High-Performance Scenarios
 ```bash
-crawld --concurrent 100 --rate-limit 50 --depth 3 https://fast-server.com
+urlmap --concurrent 100 --rate-limit 50 --depth 3 https://fast-server.com
 ```
 
 ### Environment-Specific Tuning
@@ -194,11 +194,11 @@ crawld --concurrent 100 --rate-limit 50 --depth 3 https://fast-server.com
 
 ```bash
 # Increase memory limit for large crawls
-docker run --memory=1g --rm ghcr.io/aoshimash/crawld:latest \
+docker run --memory=1g --rm ghcr.io/aoshimash/urlmap:latest \
   --concurrent 50 --depth 5 https://example.com
 
 # CPU optimization
-docker run --cpus="4.0" --rm ghcr.io/aoshimash/crawld:latest \
+docker run --cpus="4.0" --rm ghcr.io/aoshimash/urlmap:latest \
   --concurrent 40 https://example.com
 ```
 
@@ -206,7 +206,7 @@ docker run --cpus="4.0" --rm ghcr.io/aoshimash/crawld:latest \
 
 ```bash
 # Conservative settings for CI environments
-crawld --concurrent 5 --rate-limit 2 --depth 2 https://example.com
+urlmap --concurrent 5 --rate-limit 2 --depth 2 https://example.com
 ```
 
 ## 📈 Monitoring and Profiling
@@ -216,14 +216,14 @@ crawld --concurrent 5 --rate-limit 2 --depth 2 https://example.com
 #### Verbose Output Analysis
 
 ```bash
-crawld --verbose https://example.com 2>&1 | grep -E "(rate|time|memory)"
+urlmap --verbose https://example.com 2>&1 | grep -E "(rate|time|memory)"
 ```
 
 #### Statistics Tracking
 
 ```bash
 # Example output with performance metrics
-crawld --verbose https://example.com
+urlmap --verbose https://example.com
 # 2024/01/01 12:00:00 INFO Starting crawl url=https://example.com depth=0 workers=10
 # 2024/01/01 12:00:05 INFO Crawl completed total=150 successful=145 failed=5 time=5.2s
 ```
@@ -234,17 +234,17 @@ crawld --verbose https://example.com
 
 ```bash
 # Build with profiling support
-go build -o crawld-prof -tags=profile ./cmd/crawld
+go build -o urlmap-prof -tags=profile ./cmd/urlmap
 
 # Run with CPU profiling
-crawld-prof --concurrent 50 https://example.com
+urlmap-prof --concurrent 50 https://example.com
 ```
 
 #### Memory Profiling
 
 ```bash
 # Monitor memory usage during crawling
-go tool pprof crawld crawld.mem
+go tool pprof urlmap urlmap.mem
 ```
 
 #### Benchmarking
@@ -260,10 +260,10 @@ go test -bench=. -benchmem ./internal/crawler/
 
 ```bash
 # Monitor resource usage during crawling
-top -p $(pgrep crawld)
+top -p $(pgrep urlmap)
 
 # Memory usage tracking
-ps -o pid,rss,vsz -p $(pgrep crawld)
+ps -o pid,rss,vsz -p $(pgrep urlmap)
 
 # Network monitoring
 netstat -i
@@ -332,14 +332,14 @@ Total Memory ≈ Base (15MB) + (Workers × 2MB) + (URLs × 250 bytes)
 2. **Conservative Start**
    ```bash
    # Start with low concurrency
-   crawld --concurrent 5 --depth 2 https://example.com
+   urlmap --concurrent 5 --depth 2 https://example.com
    ```
 
 3. **Gradual Scaling**
    ```bash
    # Increase based on performance
-   crawld --concurrent 10 --depth 3 https://example.com
-   crawld --concurrent 20 --depth 5 https://example.com
+   urlmap --concurrent 10 --depth 3 https://example.com
+   urlmap --concurrent 20 --depth 5 https://example.com
    ```
 
 ### During Crawling
@@ -347,7 +347,7 @@ Total Memory ≈ Base (15MB) + (Workers × 2MB) + (URLs × 250 bytes)
 1. **Monitor Progress**
    ```bash
    # Use verbose mode for monitoring
-   crawld --verbose --concurrent 20 https://example.com
+   urlmap --verbose --concurrent 20 https://example.com
    ```
 
 2. **Resource Monitoring**
@@ -360,7 +360,7 @@ Total Memory ≈ Base (15MB) + (Workers × 2MB) + (URLs × 250 bytes)
 3. **Graceful Termination**
    ```bash
    # Use Ctrl+C for graceful shutdown
-   # crawld handles SIGINT properly
+   # urlmap handles SIGINT properly
    ```
 
 ### Post-Crawl Analysis
@@ -408,10 +408,10 @@ nslookup example.com
 **Diagnosis**:
 ```bash
 # Monitor memory usage
-ps aux | grep crawld
+ps aux | grep urlmap
 
 # Check for memory leaks
-valgrind crawld https://example.com
+valgrind urlmap https://example.com
 ```
 
 **Solutions**:
@@ -427,10 +427,10 @@ valgrind crawld https://example.com
 **Diagnosis**:
 ```bash
 # Check CPU usage
-top -p $(pgrep crawld)
+top -p $(pgrep urlmap)
 
 # Profile CPU usage
-go tool pprof crawld cpu.prof
+go tool pprof urlmap cpu.prof
 ```
 
 **Solutions**:
@@ -449,7 +449,7 @@ go tool pprof crawld cpu.prof
 netstat -s
 
 # Monitor connections
-ss -tuln | grep crawld
+ss -tuln | grep urlmap
 ```
 
 **Solutions**:
@@ -464,7 +464,7 @@ ss -tuln | grep crawld
 
 ```bash
 # Establish baseline performance
-time crawld --concurrent 10 --depth 2 https://example.com > baseline.txt
+time urlmap --concurrent 10 --depth 2 https://example.com > baseline.txt
 ```
 
 #### Load Scaling
@@ -473,7 +473,7 @@ time crawld --concurrent 10 --depth 2 https://example.com > baseline.txt
 # Test scaling characteristics
 for workers in 5 10 20 30 50; do
     echo "Workers: $workers"
-    time crawld --concurrent $workers --depth 3 https://example.com > /dev/null
+    time urlmap --concurrent $workers --depth 3 https://example.com > /dev/null
 done
 ```
 
@@ -481,16 +481,16 @@ done
 
 ```bash
 # Test maximum performance
-crawld --concurrent 100 --rate-limit 100 --depth 5 https://fast-server.com
+urlmap --concurrent 100 --rate-limit 100 --depth 5 https://fast-server.com
 ```
 
 #### Endurance Testing
 
 ```bash
 # Test long-running stability
-timeout 1h crawld --concurrent 20 --depth 10 https://large-site.com
+timeout 1h urlmap --concurrent 20 --depth 10 https://large-site.com
 ```
 
 ---
 
-This performance guide provides the foundation for optimizing crawld for your specific use cases and infrastructure requirements.
+This performance guide provides the foundation for optimizing urlmap for your specific use cases and infrastructure requirements.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// DefaultUserAgent is the default User-Agent string
-	DefaultUserAgent = "crawld/1.0.0 (+https://github.com/aoshimash/crawld)"
+	DefaultUserAgent = "urlmap/1.0.0 (+https://github.com/aoshimash/urlmap)"
 	// DefaultTimeout is the default HTTP timeout
 	DefaultTimeout = 30 * time.Second
 	// DefaultRetryCount is the default number of retry attempts

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -90,7 +90,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		MaxDepth:       3,
 		SameDomain:     true,
-		UserAgent:      "crawld/1.0",
+		UserAgent:      "urlmap/1.0",
 		Timeout:        30 * time.Second,
 		Logger:         slog.Default(),
 		Workers:        10,

--- a/internal/crawler/crawler_test.go
+++ b/internal/crawler/crawler_test.go
@@ -59,8 +59,8 @@ func TestDefaultConfig(t *testing.T) {
 		t.Error("Expected SameDomain to be true")
 	}
 
-	if config.UserAgent != "crawld/1.0" {
-		t.Errorf("Expected UserAgent 'crawld/1.0', got %s", config.UserAgent)
+	if config.UserAgent != "urlmap/1.0" {
+		t.Errorf("Expected UserAgent 'urlmap/1.0', got %s", config.UserAgent)
 	}
 
 	if config.Timeout != 30*time.Second {

--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,6 @@
-# Integration and E2E Tests
+# Testing
 
-This directory contains integration tests and end-to-end (E2E) tests for crawld.
+This directory contains integration tests and end-to-end (E2E) tests for urlmap.
 
 ## Directory Structure
 

--- a/test/integration/cli_test.go
+++ b/test/integration/cli_test.go
@@ -111,7 +111,7 @@ func TestCrawlCommand_BasicFunctionality(t *testing.T) {
 	binaryPath, cleanup := setupCLITest(t)
 	defer cleanup()
 
-	// Run crawld command
+	// Run urlmap command
 	cmd := exec.Command(binaryPath, server.URL)
 	output, err := cmd.Output()
 
@@ -135,7 +135,7 @@ func TestCrawlCommand_WithDepth(t *testing.T) {
 	binaryPath, cleanup := setupCLITest(t)
 	defer cleanup()
 
-	// Run crawld command with depth=2
+	// Run urlmap command with depth=2
 	cmd := exec.Command(binaryPath, "--depth=2", server.URL)
 	output, err := cmd.Output()
 
@@ -170,7 +170,7 @@ func TestCrawlCommand_WithVerboseFlag(t *testing.T) {
 	binaryPath, cleanup := setupCLITest(t)
 	defer cleanup()
 
-	// Run crawld command with verbose flag
+	// Run urlmap command with verbose flag
 	cmd := exec.Command(binaryPath, "--verbose", server.URL)
 
 	// Capture both stdout and stderr
@@ -198,7 +198,7 @@ func TestCrawlCommand_WithConcurrency(t *testing.T) {
 	binaryPath, cleanup := setupCLITest(t)
 	defer cleanup()
 
-	// Run crawld command with concurrency settings
+	// Run urlmap command with concurrency settings
 	cmd := exec.Command(binaryPath, "--concurrent=5", "--depth=2", server.URL)
 	output, err := cmd.Output()
 
@@ -218,7 +218,7 @@ func TestCrawlCommand_InvalidURL(t *testing.T) {
 	binaryPath, cleanup := setupCLITest(t)
 	defer cleanup()
 
-	// Run crawld command with invalid URL
+	// Run urlmap command with invalid URL
 	cmd := exec.Command(binaryPath, "not-a-valid-url")
 	output, err := cmd.CombinedOutput()
 
@@ -238,7 +238,7 @@ func TestCrawlCommand_NonExistentHost(t *testing.T) {
 	binaryPath, cleanup := setupCLITest(t)
 	defer cleanup()
 
-	// Run crawld command with non-existent host
+	// Run urlmap command with non-existent host
 	cmd := exec.Command(binaryPath, "http://non-existent-host-12345.example")
 
 	// Set a timeout for the command execution
@@ -315,7 +315,7 @@ func TestCrawlCommand_UserAgent(t *testing.T) {
 	binaryPath, cleanup := setupCLITest(t)
 	defer cleanup()
 
-	// Run crawld command with custom User-Agent
+	// Run urlmap command with custom User-Agent
 	customUA := "TestBot/1.0"
 	cmd := exec.Command(binaryPath, "--user-agent="+customUA, server.URL)
 	output, err := cmd.Output()

--- a/test/shared/testutils.go
+++ b/test/shared/testutils.go
@@ -23,7 +23,7 @@ type TestEnvironment struct {
 // SetupTestEnvironment creates a complete test environment
 func SetupTestEnvironment(t *testing.T) *TestEnvironment {
 	// Create temporary directory
-	tempDir, err := os.MkdirTemp("", "crawld-test-*")
+	tempDir, err := os.MkdirTemp("", "urlmap-test-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
@@ -164,8 +164,8 @@ func BuildTestBinary(t *testing.T) string {
 	return binaryPath
 }
 
-// RunCrawldCommand runs the crawld command with given arguments
-func RunCrawldCommand(binaryPath string, args ...string) (string, string, error) {
+// RunUrlmapCommand runs the urlmap command with given arguments
+func RunUrlmapCommand(binaryPath string, args ...string) (string, string, error) {
 	cmd := exec.Command(binaryPath, args...)
 
 	// Set a reasonable timeout


### PR DESCRIPTION
## Summary

This PR completes the final cleanup of the project rename from `crawld` to `urlmap` by replacing all remaining references throughout the codebase.

## Changes Made

### Core Components
- **Client User-Agent**: Updated HTTP client user-agent string from "crawld" to "urlmap"
- **Crawler User-Agent**: Updated crawler user-agent string in crawler component

### Test Files
- Updated all test files that referenced "crawld" in test names, comments, and assertions
- Fixed integration tests and shared test utilities

### Documentation
- **Architecture Documentation**: Updated all references in ARCHITECTURE.md
- **Performance Documentation**: Updated all references in PERFORMANCE.md
- **Test Documentation**: Updated test README with correct project name

### Affected Files
- `internal/client/client.go`
- `internal/client/client_test.go`
- `internal/crawler/crawler.go`
- `internal/crawler/crawler_test.go`
- `cmd/urlmap/main_test.go`
- `test/shared/testutils.go`
- `test/integration/cli_test.go`
- `docs/ARCHITECTURE.md`
- `docs/PERFORMANCE.md`
- `test/README.md`

## Why This Matters

- **Consistency**: Ensures all parts of the codebase use the correct project name
- **User Experience**: HTTP requests now properly identify as "urlmap" instead of the old "crawld" name
- **Documentation Accuracy**: All documentation now correctly reflects the current project name
- **Professional Presentation**: Eliminates confusion for users and contributors

## Testing

All existing tests continue to pass with the updated references. No functional changes were made - only naming consistency improvements.

## Related Issues

This addresses the final cleanup needed after the project was renamed from crawld to urlmap, ensuring complete consistency across the entire codebase.