### PR TITLE
feat: Change default crawl depth to unlimited (-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ docker run -it --rm ghcr.io/aoshimash/urlmap:latest /bin/sh
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
-| `--depth` | `-d` | 0 (unlimited) | Maximum crawl depth |
+| `--depth` | `-d` | -1 (unlimited) | Maximum crawl depth |
 | `--concurrent` | `-c` | 10 | Number of concurrent workers |
 | `--verbose` | `-v` | false | Enable verbose logging |
 | `--user-agent` | `-u` | urlmap/1.0.0 | Custom User-Agent string |

--- a/README_ja.md
+++ b/README_ja.md
@@ -149,7 +149,7 @@ docker run -it --rm ghcr.io/aoshimash/urlmap:latest /bin/sh
 
 | フラグ | 短縮形 | デフォルト | 説明 |
 |------|-------|---------|-------------|
-| `--depth` | `-d` | 0 (無制限) | 最大クロール深度 |
+| `--depth` | `-d` | -1 (無制限) | 最大クロール深度 |
 | `--concurrent` | `-c` | 10 | 並行ワーカー数 |
 | `--verbose` | `-v` | false | 詳細ログを有効化 |
 | `--user-agent` | `-u` | urlmap/1.0.0 | カスタムUser-Agent文字列 |

--- a/cmd/urlmap/main.go
+++ b/cmd/urlmap/main.go
@@ -62,7 +62,7 @@ var versionCmd = &cobra.Command{
 
 func init() {
 	// Add flags to the root command
-	rootCmd.Flags().IntVarP(&depth, "depth", "d", 0, "Maximum crawl depth (0 = unlimited)")
+	rootCmd.Flags().IntVarP(&depth, "depth", "d", -1, "Maximum crawl depth (-1 = unlimited)")
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	rootCmd.Flags().StringVarP(&userAgent, "user-agent", "u", "urlmap/0.2.0 (+https://github.com/aoshimash/urlmap)", "Custom User-Agent string")
 	rootCmd.Flags().IntVarP(&concurrent, "concurrent", "c", 10, "Number of concurrent requests")

--- a/cmd/urlmap/main_test.go
+++ b/cmd/urlmap/main_test.go
@@ -93,7 +93,7 @@ func TestVersionCommand(t *testing.T) {
 
 func TestFlagDefaults(t *testing.T) {
 	// Reset flags to default values
-	depth = 0
+	depth = -1
 	verbose = false
 	userAgent = "urlmap/1.0.0 (+https://github.com/aoshimash/urlmap)"
 	concurrent = 10
@@ -104,8 +104,8 @@ func TestFlagDefaults(t *testing.T) {
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Test default values
-			if depth != 0 {
-				t.Errorf("depth default should be 0, got: %d", depth)
+			if depth != -1 {
+				t.Errorf("depth default should be -1, got: %d", depth)
 			}
 			if verbose != false {
 				t.Errorf("verbose default should be false, got: %v", verbose)
@@ -120,7 +120,7 @@ func TestFlagDefaults(t *testing.T) {
 		},
 	}
 
-	cmd.Flags().IntVarP(&depth, "depth", "d", 0, "Maximum crawl depth (0 = unlimited)")
+	cmd.Flags().IntVarP(&depth, "depth", "d", -1, "Maximum crawl depth (-1 = unlimited)")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	cmd.Flags().StringVarP(&userAgent, "user-agent", "u", "urlmap/1.0.0 (+https://github.com/aoshimash/urlmap)", "Custom User-Agent string")
 	cmd.Flags().IntVarP(&concurrent, "concurrent", "c", 10, "Number of concurrent requests")
@@ -163,7 +163,7 @@ func TestFlagParsing(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Reset flags
-			depth = 0
+			depth = -1
 			verbose = false
 			userAgent = "urlmap/1.0.0 (+https://github.com/aoshimash/urlmap)"
 			concurrent = 10
@@ -189,7 +189,7 @@ func TestFlagParsing(t *testing.T) {
 				},
 			}
 
-			cmd.Flags().IntVarP(&depth, "depth", "d", 0, "Maximum crawl depth (0 = unlimited)")
+			cmd.Flags().IntVarP(&depth, "depth", "d", -1, "Maximum crawl depth (-1 = unlimited)")
 			cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 			cmd.Flags().StringVarP(&userAgent, "user-agent", "u", "urlmap/1.0.0 (+https://github.com/aoshimash/urlmap)", "Custom User-Agent string")
 			cmd.Flags().IntVarP(&concurrent, "concurrent", "c", 10, "Number of concurrent requests")


### PR DESCRIPTION
## Summary

This PR changes the default crawl depth from 0 (root only) to -1 (unlimited) to provide more comprehensive site mapping out of the box.

## Changes

- **Changed default depth flag value**: From `0` to `-1` for unlimited crawling
- **Updated help text**: Changed description to `"Maximum crawl depth (-1 = unlimited)"`
- **Updated documentation**: Modified both English and Japanese README files to reflect the new default
- **Fixed tests**: Updated test expectations for the new default value

## Before

```bash
# Default behavior (depth 0 = root only)
urlmap https://example.com
```

## After

```bash
# Default behavior (depth -1 = unlimited crawling)
urlmap https://example.com
```

## Rationale

The previous default of depth 0 (root only) was not very useful for most use cases. Users typically want to discover all URLs within a site, not just the root page. This change makes the tool more useful by default while still allowing users to limit depth when needed.

## Testing

- All existing tests pass with updated expectations
- Manual testing confirms unlimited crawling works as expected
- Help text and documentation correctly reflect the new behavior

## Breaking Change

This is a breaking change in behavior, but it makes the tool more useful by default. Users who want the old behavior can explicitly set `-d 0`.