### PR TITLE
fix: Use Playwright Docker image for CI to resolve dependency issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.48.0-noble
-      options: --user 1001
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.48.0-noble
+      options: --user 1001
 
     strategy:
       matrix:
@@ -45,22 +48,17 @@ jobs:
       - name: Build
         run: go build -v ./...
 
-      - name: Install Playwright CLI
+      - name: Install Playwright CLI for Go
         run: go install github.com/playwright-community/playwright-go/cmd/playwright@latest
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-
-      - name: Install Playwright browsers
-        run: playwright install --with-deps chromium
+      # Playwright browsers are already installed in the Docker image
+      # No need to install or cache them separately
 
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out ./...
+        env:
+          # Ensure Playwright uses the pre-installed browsers
+          PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
 
       - name: Upload coverage to Codecov
         if: matrix.go-version == '1.24'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,11 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache: true
 
-      - name: Install build dependencies
+      - name: Setup environment
         run: |
+          # Fix git ownership issue in Docker
+          git config --global --add safe.directory /__w/urlmap/urlmap
+          # Install build dependencies
           apt-get update
           apt-get install -y gcc g++ libc6-dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache: true
 
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          apt-get install -y gcc g++ libc6-dev
+
       - name: Download dependencies
         run: go mod download
 
@@ -57,6 +62,8 @@ jobs:
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out ./...
         env:
+          # Enable CGO for race detection
+          CGO_ENABLED: 1
           # Ensure Playwright uses the pre-installed browsers
           PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
 


### PR DESCRIPTION
## Summary
Fix the incomplete implementation of Phase 2 (#63) by using the official Playwright Docker image in CI, which includes all required system dependencies.

## Problem
The CI environment (Ubuntu 24.04) was missing critical system dependencies for Playwright:
- GTK4 libraries
- GStreamer libraries
- Various multimedia codecs
- And many more

The `playwright install --with-deps chromium` command was insufficient due to package naming changes in Ubuntu 24.04 (many packages now have a `t64` suffix).

## Solution
Use the official Playwright Docker image (`mcr.microsoft.com/playwright:v1.48.0-noble`) which:
- Has all system dependencies pre-installed
- Is maintained by the Playwright team
- Provides a consistent environment across CI runs
- Eliminates dependency management complexity

## Changes Made
1. Added Docker container configuration to CI workflow
2. Removed manual browser installation steps (already in Docker image)
3. Set `PLAYWRIGHT_BROWSERS_PATH` environment variable
4. Kept Playwright CLI installation for Go integration

## Testing
This PR will validate that:
- All tests pass in the Docker container
- Playwright tests can run without dependency errors
- CI performance remains acceptable

## Related Issues
- Fixes #68
- Enables completion of #64 (Phase 3)
- Related PR: #67

🤖 Generated with [Claude Code](https://claude.ai/code)